### PR TITLE
Add dfxEur deploy script, asc, twap

### DIFF
--- a/scripts/deploy-dfxeur.js
+++ b/scripts/deploy-dfxeur.js
@@ -1,0 +1,112 @@
+import fs from 'fs'
+import path from 'path'
+import ethers from 'ethers'
+import { fileURLToPath } from 'url';
+import { parseUnits } from '@ethersproject/units'
+import { wallet, deployContract } from './common.js'
+
+import DfxEurTwapArtifact from '../out/DfxEurTWAP.sol/DfxEurTWAP.json'
+import DfxEurLogicArtifact from '../out/DfxEurLogic.sol/DfxEurLogic.json'
+import ASCUpgradableProxyArtifact from '../out/ASCUpgradableProxy.sol/ASCUpgradableProxy.json'
+
+// Access controller
+const DFX_GOV_MULTISIG = '0x27E843260c71443b4CC8cB6bF226C3f77b9695AF'
+const DFX_ACCESS_CONTROLLER_MULTISIG = '0xc9f05fa7049b32712c5d6675ebded167150475c4'
+const DFX_TREASURY_MULTISIG = '0x26f539A0fE189A7f228D7982BF10Bc294FA9070c'
+
+// Manages access control in twap
+const TWAP_ROLE_ADMIN = DFX_ACCESS_CONTROLLER_MULTISIG
+
+// Proxy admin is only used for upgrading proxy logic
+const DFX_EUR_PROXY_ADMIN = DFX_GOV_MULTISIG
+
+const DFX_EUR_NAME = "dfxEUR"
+const DFX_EUR_SYMBOL = "dfxEUR"
+const DFX_EUR_ROLE_ADMIN = DFX_ACCESS_CONTROLLER_MULTISIG // DFX_CADC_ADMIN is used to manage (all) roles
+const DFX_EUR_FEE_RECIPIENT = DFX_TREASURY_MULTISIG
+const DFX_EUR_MINT_BURN_FEE = parseUnits('0.005') // 0.5%
+const EURS_RATIO = parseUnits('0.95') // 95%
+const DFX_RATIO = parseUnits('0.05') // 5%
+const POKE_RATIO_DELTA = parseUnits('0.005') // 0.5%
+
+const main = async () => {
+    const TwapFactory = new ethers.ContractFactory(
+        DfxEurTwapArtifact.abi, DfxEurTwapArtifact.bytecode.object, wallet
+    )
+    const LogicFactory = new ethers.ContractFactory(
+        DfxEurLogicArtifact.abi, DfxEurLogicArtifact.bytecode.object, wallet
+    )
+    const UpgradableProxyFactory = new ethers.ContractFactory(
+        ASCUpgradableProxyArtifact.abi, ASCUpgradableProxyArtifact.bytecode.object, wallet
+    )
+
+    // // 1. Deploy TWAP
+    const dfxEurTwap = await deployContract({
+        name: 'DfxEurTWAP',
+        deployer: wallet,
+        factory: TwapFactory,
+        args: [TWAP_ROLE_ADMIN],
+        opts: {
+            gasLimit: 2017090
+        }
+    })
+
+    // 2. Deploy logic
+    const dfxEurLogic = await deployContract({
+        name: 'DfxEurLogic',
+        deployer: wallet,
+        factory: LogicFactory,
+        args: [],
+        opts: {
+            gasLimit: 3040761
+        }
+    })
+
+    // 3. Deploy ASCUpgradableProxy with the encoded args
+    const calldata = LogicFactory.interface.encodeFunctionData("initialize", [
+        DFX_EUR_NAME, DFX_EUR_SYMBOL, DFX_EUR_ROLE_ADMIN, DFX_EUR_FEE_RECIPIENT, DFX_EUR_MINT_BURN_FEE, dfxEurTwap.address, EURS_RATIO, DFX_RATIO, POKE_RATIO_DELTA
+    ])
+    const dfxEurProxy = await deployContract({
+        name: 'DfxEur',
+        deployer: wallet,
+        factory: UpgradableProxyFactory,
+        args: [
+            dfxEurLogic.address,
+            DFX_EUR_PROXY_ADMIN,
+            calldata
+        ],
+        opts: {
+            gasLimit: 1667809
+        }
+    })
+
+    const output = {
+        dfxEurProxy: dfxEurProxy.address,
+        dfxEurLogic: dfxEurLogic.address,
+        dfxEurTwap: dfxEurTwap.address,
+        calldata: {
+            dfxEurTwap: ethers.utils.defaultAbiCoder.encode(['address'], [
+                TWAP_ROLE_ADMIN,
+            ]),
+            dfxEurProxy: ethers.utils.defaultAbiCoder.encode(['address', 'address', 'bytes'], [
+                dfxEurLogic.address,
+                DFX_EUR_PROXY_ADMIN,
+                calldata
+            ])
+        }
+    };
+
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const outputPath = path.join(__dirname, new Date().getTime().toString() + `_deployed_dfxeur.json`);
+    fs.writeFileSync(outputPath, JSON.stringify(output, null, 4));
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+    .then(() => process.exit(0))
+    .catch(error => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/src/dfxEur/DfxEurLogic.sol
+++ b/src/dfxEur/DfxEurLogic.sol
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "../interfaces/IDfxOracle.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "./DfxEurState.sol";
+
+import "../libraries/FullMath.sol";
+
+contract DfxEurLogic is DfxEurState {
+    using SafeERC20 for IERC20;
+
+    // **** Initializing functions ****
+
+    // We don't need to check twice if the contract's initialized as
+    // __ERC20_init does that check
+    function initialize(
+        string memory _name,
+        string memory _symbol,
+        address _admin,
+        address _feeRecipient,
+        uint256 _mintBurnFee,
+        address _dfxEurTwap,
+        uint256 _eursRatio,
+        uint256 _dfxRatio,
+        uint256 _pokeRatioDelta
+    ) public initializer {
+        __AccessControl_init();
+        __ERC20_init(_name, _symbol);
+        __Pausable_init();
+        __ReentrancyGuard_init();
+
+        _setRoleAdmin(SUDO_ROLE, SUDO_ROLE_ADMIN);
+        _setupRole(SUDO_ROLE_ADMIN, _admin);
+        _setupRole(SUDO_ROLE, _admin);
+
+        _setRoleAdmin(MARKET_MAKER_ROLE, MARKET_MAKER_ROLE_ADMIN);
+        _setupRole(MARKET_MAKER_ROLE_ADMIN, _admin);
+        _setupRole(MARKET_MAKER_ROLE, _admin);
+
+        _setRoleAdmin(POKE_ROLE, POKE_ROLE_ADMIN);
+        _setupRole(POKE_ROLE_ADMIN, _admin);
+        _setupRole(POKE_ROLE, _admin);
+
+        _setRoleAdmin(CR_DEFENDER, CR_DEFENDER_ADMIN);
+        _setupRole(CR_DEFENDER_ADMIN, _admin);
+        _setupRole(CR_DEFENDER, _admin);
+
+        // Oracle address
+        dfxEurTwap = _dfxEurTwap;
+
+        // Initial ratios
+        require(_dfxRatio + _eursRatio == 1e18, "invalid-ratio");
+        eursRatio = _eursRatio;
+        dfxRatio = _dfxRatio;
+
+        // Poke ratio delta
+        require(
+            _pokeRatioDelta <= MAX_POKE_RATIO_DELTA,
+            "poke-ratio-delta: too big"
+        );
+        pokeRatioDelta = _pokeRatioDelta;
+
+        // Fee recipients
+        feeRecipient = _feeRecipient;
+        mintBurnFee = _mintBurnFee;
+    }
+
+    // **** Modifiers ****
+
+    modifier updatePokes() {
+        // Make sure we can poke
+        require(
+            block.timestamp > lastPokeTime + POKE_WAIT_PERIOD,
+            "invalid-poke-time"
+        );
+
+        _;
+
+        // Sanity checks
+        require(
+            dfxRatio > 0 &&
+                dfxRatio < 1e18 &&
+                eursRatio > 0 &&
+                eursRatio < 1e18,
+            "invalid-ratios"
+        );
+
+        lastPokeTime = block.timestamp;
+    }
+
+    // **** Restricted functions ****
+
+    // Sets the 'poke' delta
+    /// @notice Manually sets the delta between each poke
+    /// @param _pokeRatioDelta The delta between each poke, 100% = 1e18.
+    function setPokeDelta(uint256 _pokeRatioDelta) public onlyRole(SUDO_ROLE) {
+        require(
+            _pokeRatioDelta <= MAX_POKE_RATIO_DELTA,
+            "poke-ratio-delta: too big"
+        );
+        pokeRatioDelta = _pokeRatioDelta;
+        emit PokeDeltaSet(pokeRatioDelta);
+    }
+
+    /// @notice Used when market price / TWAP is > than backing.
+    ///         If set correctly, the underlying backing of the stable
+    ///         assets will decrease and the underlying backing of the volatile
+    ///         assets will increase.
+    function pokeUp() public onlyRole(POKE_ROLE) updatePokes {
+        dfxRatio = dfxRatio + pokeRatioDelta;
+        eursRatio = eursRatio - pokeRatioDelta;
+        emit PokeUp(dfxRatio, eursRatio);
+    }
+
+    /// @notice Used when market price / TWAP is < than backing.
+    ///         If set correctly, the underlying backing of the stable
+    ///         assets will increase and the underlying backing of the volatile
+    ///         assets will decrease
+    function pokeDown() public onlyRole(POKE_ROLE) updatePokes {
+        dfxRatio = dfxRatio - pokeRatioDelta;
+        eursRatio = eursRatio + pokeRatioDelta;
+        emit PokeDown(dfxRatio, eursRatio);
+    }
+
+    /// @notice Sets the TWAP address
+    function setDfxEurTwap(address _dfxXgdTwap) public onlyRole(SUDO_ROLE) {
+        dfxEurTwap = _dfxXgdTwap;
+        emit DfxEurTwapSet(_dfxXgdTwap);
+    }
+
+    /// @notice Sets the fee recipient for mint/burn
+    function setFeeRecipient(address _recipient) public onlyRole(SUDO_ROLE) {
+        feeRecipient = _recipient;
+        emit FeeRecipientSet(_recipient);
+    }
+
+    /// @notice In case anyone sends tokens to the wrong address
+    function recoverERC20(address _a) public onlyRole(SUDO_ROLE) {
+        require(_a != DFX && _a != EURS, "no");
+        IERC20(_a).safeTransfer(
+            msg.sender,
+            IERC20(_a).balanceOf(address(this))
+        );
+        emit ERC20Recovered(_a);
+    }
+
+    /// @notice Sets mint/burn fee
+    function setMintBurnFee(uint256 _f) public onlyRole(SUDO_ROLE) {
+        require(_f < 1e18, "invalid-fee");
+        mintBurnFee = _f;
+        emit MintBurnFeeSet(_f);
+    }
+
+    /// @notice Emergency trigger
+    function setPaused(bool _p) public onlyRole(SUDO_ROLE) {
+        if (_p) {
+            _pause();
+        } else {
+            _unpause();
+        }
+    }
+
+    /// @notice Execute functionality used to perform buyback and recollateralization
+    function execute(address _target, bytes memory _data)
+        public
+        onlyRole(CR_DEFENDER)
+        returns (bytes memory response)
+    {
+        require(_target != address(0), "target-address-required");
+
+        // call contract in current context
+        assembly {
+            let succeeded := delegatecall(
+                sub(gas(), 5000),
+                _target,
+                add(_data, 0x20),
+                mload(_data),
+                0,
+                0
+            )
+            let size := returndatasize()
+
+            response := mload(0x40)
+            mstore(
+                0x40,
+                add(response, and(add(add(size, 0x20), 0x1f), not(0x1f)))
+            )
+            mstore(response, size)
+            returndatacopy(add(response, 0x20), 0, size)
+
+            switch iszero(succeeded)
+            case 1 {
+                // throw if delegatecall failed
+                revert(add(response, 0x20), size)
+            }
+        }
+        emit Executed(_target);
+    }
+
+    // **** Public stateful functions ****
+
+    /// @notice Mints the ASC token
+    /// @param _amount Amount of ASC token to mint
+    function mint(uint256 _amount) public nonReentrant whenNotPaused {
+        require(_amount > 0, "non-zero only");
+
+        (uint256 eursAmount, uint256 dfxAmount) = getUnderlyings(_amount);
+        IERC20(EURS).safeTransferFrom(msg.sender, address(this), eursAmount);
+        IERC20(DFX).safeTransferFrom(msg.sender, address(this), dfxAmount);
+
+        // No fee for market makers
+        if (hasRole(MARKET_MAKER_ROLE, msg.sender)) {
+            _mint(msg.sender, _amount);
+        } else {
+            uint256 _fee = (_amount * mintBurnFee) / 1e18;
+            _mint(msg.sender, _amount - _fee);
+            _mint(feeRecipient, _fee);
+        }
+    }
+
+    /// @notice Burns the ASC token
+    /// @param _amount Amount of ASC token to burn
+    function burn(uint256 _amount) public nonReentrant whenNotPaused {
+        require(_amount > 0, "non-zero only");
+
+        // No fee for market makers
+        if (hasRole(MARKET_MAKER_ROLE, msg.sender)) {
+            _burn(msg.sender, _amount);
+        } else {
+            uint256 _fee = (_amount * mintBurnFee) / 1e18;
+            _burn(msg.sender, _amount);
+            _mint(feeRecipient, _fee);
+            _amount = _amount - _fee;
+        }
+
+        (uint256 eursAmount, uint256 dfxAmount) = getUnderlyings(_amount);
+        IERC20(EURS).safeTransfer(msg.sender, eursAmount);
+        IERC20(DFX).safeTransfer(msg.sender, dfxAmount);
+    }
+
+    // **** View only functions ****
+
+    /// @notice Get the underlyings of `_amount` of 'logic' tokens
+    ///         For example, how many underlyings will `_amount` token yield?
+    ///         Or, how many underlyings do I need to mint `_amount` token?
+    /// @param _amount The amount of 'logic' token
+    function getUnderlyings(uint256 _amount)
+        public
+        view
+        returns (uint256 eursAmount, uint256 dfxAmount)
+    {
+        uint256 eurPerDfx = IDfxOracle(dfxEurTwap).read();
+
+        eursAmount = FullMath.mulDivRoundingUp(_amount, eursRatio, 1e34);
+        dfxAmount = FullMath.mulDivRoundingUp(_amount, dfxRatio, 1e18);
+        dfxAmount = FullMath.mulDivRoundingUp(dfxAmount, 1e18, eurPerDfx);
+    }
+
+    /* ========== EVENTS ========== */
+    event Executed(address user);
+    event MintBurnFeeSet(uint256 fee);
+    event ERC20Recovered(address user);
+    event FeeRecipientSet(address user);
+    event DfxEurTwapSet(address twap);
+    event PokeDown(uint256 dfxRatio, uint256 eursRatio);
+    event PokeUp(uint256 dfxRatio, uint256 eursRatio);
+    event PokeDeltaSet(uint256 pokeRatioDelta);
+}

--- a/src/dfxEur/DfxEurState.sol
+++ b/src/dfxEur/DfxEurState.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "@openzeppelin-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/access/AccessControlUpgradeable.sol";
+import "../common/ERC20Upgradeable.sol";
+
+contract DfxEurState is
+    AccessControlUpgradeable,
+    ERC20Upgradeable,
+    PausableUpgradeable,
+    ReentrancyGuardUpgradeable
+{
+    /***** Constants *****/
+
+    // Super user role
+    bytes32 public constant SUDO_ROLE = keccak256("dfxeur.role.sudo");
+    bytes32 public constant SUDO_ROLE_ADMIN = keccak256("dfxeur.role.sudo.admin");
+
+    // Poke role
+    bytes32 public constant POKE_ROLE = keccak256("dfxeur.role.poke");
+    bytes32 public constant POKE_ROLE_ADMIN = keccak256("dfxeur.role.poke.admin");
+
+    // Market makers don't need to pay a mint/burn fee
+    bytes32 public constant MARKET_MAKER_ROLE = keccak256("dfxeur.role.mm");
+    bytes32 public constant MARKET_MAKER_ROLE_ADMIN =
+        keccak256("dfxeur.role.mm.admin");
+    
+    // Collateral defenders to perform buyback and recollateralization
+    bytes32 public constant CR_DEFENDER = keccak256("dfxeur.role.cr-defender");
+    bytes32 public constant CR_DEFENDER_ADMIN = keccak256("dfxeur.role.cr-defender.admin");
+
+    // Can only poke the contracts every day
+    uint256 public constant POKE_WAIT_PERIOD = 1 days;
+    uint256 public constant MAX_POKE_RATIO_DELTA = 1e16; // 1% max change per day
+
+    // Underlyings
+    address public constant DFX = 0x888888435FDe8e7d4c54cAb67f206e4199454c60;
+    address public constant EURS = 0xdB25f211AB05b1c97D595516F45794528a807ad8;
+
+    /***** Variables *****/
+
+    /* !!!! Important !!!! */
+    // Do _not_ change the layout of the variables
+    // as you'll be changing the slots
+
+    // TWAP Oracle address
+    // 1 DFX = EURS?
+    address public dfxEurTwap;
+
+    // Will only be backed by DFX and EURS so this should be sufficient
+    // Ratio should be number between 0 - 1e18
+    // dfxRatio + eursRatio should equal to 1e18
+    // 5e17 = ratio of 50%
+    uint256 public eursRatio;
+    uint256 public dfxRatio;
+
+    // How much delta will each 'poke' consist of
+    // i.e. say pokeRatioDelta = 1e16 = 1%
+    //      dfxRatio = 5e17 = 50%
+    //      eursRatio = 5e17 = 50%
+    // Poking up = dfxRatio = 51e16 = 51%
+    //             eursRatio = 49e16 = 49%
+    // Poking down = dfxRatio = 49e16 = 49%
+    //             eursRatio = 51e16 = 51%
+    uint256 public pokeRatioDelta;
+
+    // Fee recipient and mint/burn fee, starts off at 0.5%
+    address public feeRecipient;
+    uint256 public mintBurnFee;
+
+    // Last poke time
+    uint256 public lastPokeTime;
+}

--- a/src/oracles/DfxEurTWAP.sol
+++ b/src/oracles/DfxEurTWAP.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// https://github.com/Uniswap/v2-periphery/blob/master/contracts/examples/ExampleOracleSimple.sol
+
+pragma solidity ^0.8.10;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/IDfxOracle.sol";
+import "../interfaces/IChainLinkOracle.sol";
+
+import "./UniswapV2Oracle.sol";
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+contract DfxEurTWAP is AccessControl, UniswapV2Oracle, IDfxOracle {
+    // **** Roles **** //
+    bytes32 public constant SUDO = keccak256("dfxeur.twap.sudo");
+    bytes32 public constant SUDO_ADMIN = keccak256("dfxeur.twap.sudo.admin");
+
+    // **** Constants **** //
+    address internal constant SUSHI_FACTORY =
+        0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac;
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address internal constant DFX = 0x888888435FDe8e7d4c54cAb67f206e4199454c60;
+
+    IChainLinkOracle ETH_USD_ORACLE =
+        IChainLinkOracle(0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419);
+    IChainLinkOracle EUR_USD_ORACLE =
+        IChainLinkOracle(0xb49f677943BC038e9857d61E7d053CaA2C1734C1);
+
+    constructor(address _admin)
+        UniswapV2Oracle(SUSHI_FACTORY, DFX, WETH, 6 hours)
+    {
+        _setRoleAdmin(SUDO, SUDO_ADMIN);
+        _setupRole(SUDO_ADMIN, _admin);
+        _setupRole(SUDO, _admin);
+    }
+
+    // **** Restricted functions **** //
+
+    /// @notice Reads the price feed and updates internal TWAP state
+    function update() public override onlyRole(SUDO) {
+        super.update();
+        emit Updated(price0CumulativeLast, price1CumulativeLast, blockTimestampLast);
+    }
+
+    /// @notice Changes the TWAP period
+    function setPeriod(uint256 _period) public onlyRole(SUDO) {
+        period = _period;
+        emit PeriodSet(period);
+    }
+
+    // **** Public functions **** //
+
+    /// @notice Returns price of DFX in EUR, e.g. 1 DFX = EURS
+    ///         Will assume 1 EURS = 1 EUR in this case
+    function read() public view override returns (uint256) {
+        // 18 dec
+        uint256 wethPerDfx18 = consult(DFX, 1e18);
+
+        // in256, 8 dec -> uint256 18 dec
+        (, int256 usdPerEth8, , , ) = ETH_USD_ORACLE.latestRoundData();
+        (, int256 usdPerEur8, , , ) = EUR_USD_ORACLE.latestRoundData();
+        uint256 usdPerEth18 = uint256(usdPerEth8) * 1e10;
+        uint256 usdPerEur18 = uint256(usdPerEur8) * 1e10;
+
+        // (eth/dfx) * (usd/eth) = usd/dfx
+        uint256 usdPerDfx = (wethPerDfx18 * usdPerEth18) / 1e18;
+
+        // (usd/dfx) / (usd/eur) = eur/dfx
+        uint256 eurPerDfx = (usdPerDfx * 1e18) / usdPerEur18;
+
+        return eurPerDfx;
+    }
+
+    /* ========== EVENTS ========== */
+    event Updated(uint256 price0CumulativeLast, uint256 price1CumulativeLast, uint32 blockTimestampLast);
+    event PeriodSet(uint256 period);
+}

--- a/src/test/dfxEur/DfxEurLogic.t.sol
+++ b/src/test/dfxEur/DfxEurLogic.t.sol
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "ds-test/test.sol";
+import {stdCheats} from "@forge-std/stdlib.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "../lib/MockToken.sol";
+import "../lib/MockUser.sol";
+import "../lib/MockLogic.sol";
+import "../lib/Address.sol";
+import "../lib/CheatCodes.sol";
+
+import "../../oracles/DfxEurTWAP.sol";
+import "../../dfxEur/DfxEurLogic.sol";
+import "../../ASCUpgradableProxy.sol";
+
+import "../../interfaces/IDfxCurve.sol";
+
+contract DfxEurLogicTest is DSTest, stdCheats {
+    // Did it this way to obtain interface
+    DfxEurLogic dfxEur;
+
+    ASCUpgradableProxy upgradeableProxy;
+    DfxEurLogic logic;
+    DfxEurTWAP twap;
+
+    IERC20 dfx = IERC20(Mainnet.DFX);
+    IERC20 eurs = IERC20(Mainnet.EURS);
+    IERC20 usdc = IERC20(Mainnet.USDC);
+
+    // Mock users so we can have many addresses
+    MockUser admin;
+    MockUser accessAdmin;
+    MockUser feeCollector;
+    MockUser regularUser;
+
+    MockLogic ml;
+
+    // Cheatcodes
+    CheatCodes cheats = CheatCodes(HEVM_ADDRESS);
+
+    // MINT BURN FEE
+    // 0.5%
+    uint256 internal constant MINT_BURN_FEE = 5e15;
+
+    // Ratios
+    uint256 internal constant DFX_RATIO = 5e16; // 5%
+    uint256 internal constant EURS_RATIO = 95e16; // 95%s
+    uint256 internal constant POKE_DELTA_RATIO = 1e16; // 1%
+
+    // Used to calculate spot prices
+    IUniswapV2Router02 sushiRouter = IUniswapV2Router02(Mainnet.SUSHI_ROUTER);
+    IDfxCurve dfxUsdcEursA =
+        IDfxCurve(0x1a4Ffe0DCbDB4d551cfcA61A5626aFD190731347);
+
+    function setUp() public {
+        ml = new MockLogic();
+        admin = new MockUser();
+        accessAdmin = new MockUser();
+        regularUser = new MockUser();
+        feeCollector = new MockUser();
+
+        twap = new DfxEurTWAP(address(this));
+        cheats.warp(block.timestamp + twap.period() + 1);
+        twap.update();
+
+        logic = new DfxEurLogic();
+        bytes memory callargs = abi.encodeWithSelector(
+            DfxEurLogic.initialize.selector,
+            "Coin",
+            "COIN",
+            address(accessAdmin),
+            address(feeCollector),
+            MINT_BURN_FEE,
+            address(twap),
+            EURS_RATIO,
+            DFX_RATIO,
+            POKE_DELTA_RATIO
+        );
+
+        upgradeableProxy = new ASCUpgradableProxy(
+            address(logic),
+            address(admin),
+            callargs
+        );
+
+        dfxEur = DfxEurLogic(address(upgradeableProxy));
+
+        eurs.approve(address(dfxEur), type(uint256).max);
+        dfx.approve(address(dfxEur), type(uint256).max);
+    }
+
+    function tipEurs(address _recipient, uint256 _amount) internal {
+        // Tip doesn't work on proxies :\
+        cheats.store(
+            Mainnet.EURS,
+            keccak256(abi.encode(_recipient, 0)), // slot 0
+            bytes32(_amount)
+        );
+    }
+
+    function testFail_dfxeur_reinitialize() public {
+        admin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(
+                DfxEurLogic.initialize.selector,
+                "Coin",
+                "COIN",
+                address(accessAdmin),
+                address(feeCollector),
+                MINT_BURN_FEE,
+                address(twap),
+                EURS_RATIO,
+                DFX_RATIO,
+                POKE_DELTA_RATIO
+            )
+        );
+    }
+
+    function test_dfxeur_erc20() public {
+        assertEq(dfxEur.name(), "Coin");
+        assertEq(dfxEur.symbol(), "COIN");
+        assertEq(dfxEur.totalSupply(), 0);
+
+        assertEq(upgradeableProxy.getAdmin(), address(admin));
+        assertTrue(dfxEur.hasRole(dfxEur.SUDO_ROLE(), address(accessAdmin)));
+        assertTrue(dfxEur.hasRole(dfxEur.MARKET_MAKER_ROLE(), address(accessAdmin)));
+    }
+
+    function test_dfxeur_access_control() public {
+        MockUser newUser = new MockUser();
+
+        assertTrue(
+            !dfxEur.hasRole(dfxEur.MARKET_MAKER_ROLE(), address(newUser))
+        );
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(
+                dfxEur.grantRole.selector,
+                dfxEur.MARKET_MAKER_ROLE(),
+                address(newUser)
+            )
+        );
+        assertTrue(
+            dfxEur.hasRole(dfxEur.MARKET_MAKER_ROLE(), address(newUser))
+        );
+
+        assertTrue(!dfxEur.hasRole(dfxEur.SUDO_ROLE(), address(newUser)));
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(
+                dfxEur.grantRole.selector,
+                dfxEur.SUDO_ROLE(),
+                address(newUser)
+            )
+        );
+        assertTrue(dfxEur.hasRole(dfxEur.SUDO_ROLE(), address(newUser)));
+    }
+
+    function testFail_dfxeur_access_pokedelta() public {
+        regularUser.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.setPokeDelta.selector, 1e15)
+        );
+    }
+
+    function testFail_dfxeur_access_pokeUp() public {
+        regularUser.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeUp.selector)
+        );
+    }
+
+    function testFail_dfxeur_access_pokeDown() public {
+        regularUser.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeDown.selector)
+        );
+    }
+
+    function testFail_dfxeur_access_setdfxeurtwap() public {
+        regularUser.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.setDfxEurTwap.selector, address(0))
+        );
+    }
+
+    function testFail_dfxeur_access_recoverERC20() public {
+        regularUser.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.recoverERC20.selector, Mainnet.DAI)
+        );
+    }
+
+    function testFail_dfxeur_access_execute() public {
+        regularUser.call(
+            address(dfxEur),
+            abi.encodeWithSelector(
+                dfxEur.execute.selector,
+                address(ml),
+                abi.encodeWithSelector(ml.doSomething.selector)
+            )
+        );
+    }
+
+    function test_dfxeur_access_execute() public {
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(
+                dfxEur.grantRole.selector,
+                dfxEur.CR_DEFENDER(),
+                address(regularUser)
+            )
+        );
+
+        regularUser.call(
+            address(dfxEur),
+            abi.encodeWithSelector(
+                dfxEur.execute.selector,
+                address(ml),
+                abi.encodeWithSelector(ml.doSomething.selector)
+            )
+        );
+    }
+
+    function test_dfxeur_get_underlyings() public {
+        (uint256 eursAmount, uint256 dfxAmount) = dfxEur.getUnderlyings(
+            100e18
+        );
+        uint256 eurPerDfx = twap.read();
+        // Multiple by 1e16 to match dfx decimal places
+        uint256 sum = (eursAmount * 1e16) + ((dfxAmount * eurPerDfx) / 1e18);
+
+        // Should add to 100 EUR
+        // Assume 1 EURS = 1 EUR
+        assertLe(sum, 100e18);
+        assertGt(sum, 9999e16);
+    }
+
+    function test_dfxeur_mint(uint256 lpAmount) public {
+        cheats.assume(lpAmount > 1e6);
+        cheats.assume(lpAmount < 1_000_000_000e18);
+
+        (uint256 eursAmount, uint256 dfxAmount) = dfxEur.getUnderlyings(
+            lpAmount
+        );
+
+        tipEurs(address(this), eursAmount);
+        tip(Mainnet.DFX, address(this), dfxAmount);
+        
+        dfxEur.mint(lpAmount);
+        uint256 fee = (lpAmount * dfxEur.mintBurnFee()) / 1e18;
+        assertEq(dfxEur.balanceOf(address(this)), lpAmount - fee);
+    }
+
+    function test_dfxeur_mint_no_fees(uint256 lpAmount) public {
+        cheats.assume(lpAmount > 1e6);
+        cheats.assume(lpAmount < 1_000_000_000e18);
+
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(
+                dfxEur.grantRole.selector,
+                dfxEur.MARKET_MAKER_ROLE(),
+                address(this)
+            )
+        );
+
+        (uint256 eursAmount, uint256 dfxAmount) = dfxEur.getUnderlyings(
+            lpAmount
+        );
+
+        tipEurs(address(this), eursAmount);
+        tip(Mainnet.DFX, address(this), dfxAmount);
+
+        dfxEur.mint(lpAmount);
+        assertEq(dfxEur.balanceOf(address(this)), lpAmount);
+    }
+
+    function test_dfxeur_burn(uint256 lpAmount) public {
+        test_dfxeur_mint_no_fees(lpAmount);
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(
+                dfxEur.revokeRole.selector,
+                dfxEur.MARKET_MAKER_ROLE(),
+                address(this)
+            )
+        );
+
+        // Burn
+        dfxEur.burn(lpAmount);
+
+        // Mint + burn fee
+        uint256 _fee = (lpAmount * dfxEur.mintBurnFee()) / 1e18;
+        (uint256 eursAmount, uint256 dfxAmount) = dfxEur.getUnderlyings(
+            lpAmount - _fee
+        );
+
+        assertEq(dfxEur.balanceOf(address(feeCollector)), _fee);
+        assertEq(eurs.balanceOf(address(this)), eursAmount);
+        assertEq(dfx.balanceOf(address(this)), dfxAmount);
+    }
+
+    function test_dfxeur_burn_no_fee(uint256 lpAmount) public {
+        test_dfxeur_mint_no_fees(lpAmount);
+
+        dfxEur.burn(lpAmount);
+        (uint256 eursAmount, uint256 dfxAmount) = dfxEur.getUnderlyings(
+            lpAmount
+        );
+
+        assertEq(eurs.balanceOf(address(this)), eursAmount);
+        assertEq(dfx.balanceOf(address(this)), dfxAmount);
+    }
+
+    function test_dfxeur_poke_up() public {
+        uint256 eursR0 = dfxEur.eursRatio();
+        uint256 dfxR0 = dfxEur.dfxRatio();
+
+        (uint256 eursAmount0, uint256 dfxAmount0) = dfxEur.getUnderlyings(
+            1e18
+        );
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeUp.selector, new bytes(0))
+        );
+        (uint256 eursAmount1, uint256 dfxAmount1) = dfxEur.getUnderlyings(
+            1e18
+        );
+
+        uint256 eursR1 = dfxEur.eursRatio();
+        uint256 dfxR1 = dfxEur.dfxRatio();
+
+        assertLt(eursAmount1, eursAmount0);
+        assertGt(dfxAmount1, dfxAmount0);
+
+        assertLt(eursR1, eursR0);
+        assertGt(dfxR1, dfxR0);
+    }
+    
+    function test_dfxeur_poke_down() public {
+        uint256 eursR0 = dfxEur.eursRatio();
+        uint256 dfxR0 = dfxEur.dfxRatio();
+
+        (uint256 eursAmount0, uint256 dfxAmount0) = dfxEur.getUnderlyings(
+            1e18
+        );
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeDown.selector, new bytes(0))
+        );
+        (uint256 eursAmount1, uint256 dfxAmount1) = dfxEur.getUnderlyings(
+            1e18
+        );
+
+        uint256 eursR1 = dfxEur.eursRatio();
+        uint256 dfxR1 = dfxEur.dfxRatio();
+
+        assertGt(eursAmount1, eursAmount0);
+        assertLt(dfxAmount1, dfxAmount0);
+
+        assertGt(eursR1, eursR0);
+        assertLt(dfxR1, dfxR0);
+    }
+
+    function test_dfxeur_poke_up_2() public {
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeUp.selector, new bytes(0))
+        );
+        cheats.warp(block.timestamp + dfxEur.POKE_WAIT_PERIOD() + 1);
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeUp.selector, new bytes(0))
+        );
+    }
+
+    function testFail_dfxeur_poke_up_2() public {
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeUp.selector, new bytes(0))
+        );
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeUp.selector, new bytes(0))
+        );
+    }
+
+    function test_dfxeur_poke_down_2() public {
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeDown.selector, new bytes(0))
+        );
+        cheats.warp(block.timestamp + dfxEur.POKE_WAIT_PERIOD() + 1);
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeDown.selector, new bytes(0))
+        );
+    }
+
+    function testFail_dfxeur_poke_down_2() public {
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeDown.selector, new bytes(0))
+        );
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.pokeDown.selector, new bytes(0))
+        );
+    }
+
+    function testFail_dfxeur_paused_mint() public {
+        test_dfxeur_mint(100e18);
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.setPaused.selector, true)
+        );
+        cheats.expectRevert("Pausable: paused");
+        test_dfxeur_mint(1e18);
+    }
+
+    function testFail_dfxeur_paused_burn() public {
+        test_dfxeur_burn(1e18);
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.setPaused.selector, true)
+        );
+        cheats.expectRevert("Pausable: paused");
+        test_dfxeur_burn(1e18);
+    }
+
+    function test_dfxeur_unpause() public {
+        // Contract can be unpaused
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.setPaused.selector, true)
+        );
+
+        cheats.expectRevert("Pausable: paused");
+        dfxEur.mint(100e18);
+
+        // unpause and try again
+        accessAdmin.call(
+            address(dfxEur),
+            abi.encodeWithSelector(dfxEur.setPaused.selector, false)
+        );
+        test_dfxeur_mint(100e18);
+    }
+
+    function test_dfxeur_mint_burn_spotprice() public {
+        assertEq(dfx.balanceOf(address(this)), 0);
+        assertEq(eurs.balanceOf(address(this)), 0);
+
+        // Mint + burn one token w/o fees
+        test_dfxeur_burn_no_fee(1e18);
+
+        // Now we go from
+        // DFX -> WETH -> USDC @ sushi
+        // USDC -> EURS @ dfx
+        // And see if we end up with 1 EURS
+        address[] memory path = new address[](3);
+        path[0] = Mainnet.DFX;
+        path[1] = Mainnet.WETH;
+        path[2] = Mainnet.USDC;
+        uint256 usdcOut = sushiRouter.getAmountsOut(
+            dfx.balanceOf(address(this)),
+            path
+        )[2];
+        uint256 eursOutFromDfx = dfxUsdcEursA.viewOriginSwap(
+            address(usdc),
+            address(eurs),
+            usdcOut
+        );
+
+        uint256 totalEursOut = eursOutFromDfx + eurs.balanceOf(address(this));
+
+        assertLe(totalEursOut, 1.01e2);
+        assertGt(totalEursOut, 0.98e2);
+    }
+}

--- a/src/test/lib/Address.sol
+++ b/src/test/lib/Address.sol
@@ -9,6 +9,7 @@ library Mainnet {
     address public constant DFX = 0x888888435FDe8e7d4c54cAb67f206e4199454c60;
     address public constant CADC = 0xcaDC0acd4B445166f12d2C07EAc6E2544FbE2Eef;
     address public constant XSGD = 0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96;
+    address public constant EURS = 0xdB25f211AB05b1c97D595516F45794528a807ad8;
 
     address public constant DFX_CAD = 0xFE32747d0251BA92bcb80b6D16C8257eCF25AB1C;
     address public constant DFX_CAD_GOV = 0x27E843260c71443b4CC8cB6bF226C3f77b9695AF;

--- a/src/test/oracles/DfxEurTWAP.t.sol
+++ b/src/test/oracles/DfxEurTWAP.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "ds-test/test.sol";
+import "../lib/Address.sol";
+import "../lib/CheatCodes.sol";
+
+import {stdCheats} from "@forge-std/stdlib.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "../../interfaces/IChainLinkOracle.sol";
+import "../../interfaces/IUniswapV2.sol";
+import "../../interfaces/IDfxCurve.sol";
+
+import "../../oracles/DfxEurTWAP.sol";
+
+contract DfxEurTWAPTest is DSTest, stdCheats {
+    DfxEurTWAP twap;
+
+    CheatCodes cheats = CheatCodes(HEVM_ADDRESS);
+
+    IUniswapV2Router02 sushiRouter = IUniswapV2Router02(Mainnet.SUSHI_ROUTER);
+    IDfxCurve dfxUsdEurA =
+        IDfxCurve(0x1a4Ffe0DCbDB4d551cfcA61A5626aFD190731347);
+
+    IERC20 dfx = IERC20(Mainnet.DFX);
+    IERC20 eurs = IERC20(Mainnet.EURS);
+    IERC20 usdc = IERC20(Mainnet.USDC);
+
+    function setUp() public {
+        twap = new DfxEurTWAP(address(this));
+        dfx.approve(address(sushiRouter), type(uint256).max);
+        usdc.approve(address(dfxUsdEurA), type(uint256).max);
+    }
+
+    function test_dfxeurtwap() public {
+        uint256 eurPerDfx = twap.read();
+        assertGt(eurPerDfx, 0);
+
+        cheats.warp(block.timestamp + twap.period() + 1);
+        twap.update();
+        cheats.warp(block.timestamp + twap.period() + 1);
+        twap.update();
+
+        eurPerDfx = twap.read();
+        assertGt(eurPerDfx, 0);
+
+        // Now do a real world comparison
+        // 1 DFX -> WETH -> USDC @ sushi
+        // USDC -> EURS @ dfx
+        uint256 _before = eurs.balanceOf(address(this));
+        address[] memory path = new address[](3);
+        path[0] = Mainnet.DFX;
+        path[1] = Mainnet.WETH;
+        path[2] = Mainnet.USDC;
+
+        tip(address(dfx), address(this), 1e18);
+        sushiRouter.swapExactTokensForTokens(
+            1e18,
+            0,
+            path,
+            address(this),
+            block.timestamp
+        );
+        dfxUsdEurA.originSwap(
+            address(usdc),
+            address(eurs),
+            usdc.balanceOf(address(this)),
+            0,
+            block.timestamp + 1
+        );
+
+        // 1e16 Adjusting for eurs decimal places
+        uint256 spotEurPerDfx = (eurs.balanceOf(address(this)) - _before) * 1e16;
+
+        uint256 deltaPercentage = eurPerDfx > spotEurPerDfx
+            ? (spotEurPerDfx * 1e18) / eurPerDfx
+            : (eurPerDfx * 1e18) / spotEurPerDfx;
+
+        // Correct up to 96% (less because EURS is 2 decimals) 
+        assertGt(deltaPercentage, 96e16);
+    }
+}


### PR DESCRIPTION

Similar to dfxSgd Decided to use 18 decimals for dfxEur TWAP. 
https://github.com/dfx-finance/asc/pull/28/files#diff-12b374f24add64c1499179f11724b6e41cbdb3cdd927ea1e3e5dd043d4c786a9R258
Adjusted the denominator to reflect EUR's decimals (18+(18-2) = 34) as well as the tests affected by `getUnderlyings(uint256 _amount)`

TWAP test reduced to 96 percent because of EUR's 2 decimals
https://github.com/dfx-finance/asc/pull/28/files#diff-aaa29ac93c2ce214100e8670db1a45b48ddb303a4bfdeaa0a3f4f78343cf8eadR81

Same here
https://github.com/dfx-finance/asc/pull/28/files#diff-58c7122ed6cda4479ba24410f4720d67956c249b411e11f266801887dba065c3R479-R480